### PR TITLE
Update Bootstrap Layout

### DIFF
--- a/src/Packages/Bootstrap/resources/views/dashboard.blade.php
+++ b/src/Packages/Bootstrap/resources/views/dashboard.blade.php
@@ -8,7 +8,7 @@
         </div>
     </div>
 
-    <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
+    <div class="col-sm-9 col-md-10 main">
         @yield('content')
     </div>
 


### PR DESCRIPTION
Bootstrap doesn't need the offsets. This causes the page to display incorrectly. The offsets are useful when centering or when swapping two columns on different screen sizes, but on this occasion, there is already a column with width 2 and another with 10, so you can't offset by another 2 as that equals 14. Let me know if they were there for another purpose.