### PR TITLE
Laravel Middleware Compliant parameters policy

### DIFF
--- a/src/Packages/Starter/app/Http/Middleware/Roles.php
+++ b/src/Packages/Starter/app/Http/Middleware/Roles.php
@@ -15,14 +15,8 @@ class Roles
      * @param  \Closure  $next
      * @return mixed
      */
-    public function handle($request, Closure $next, $roleCollection)
+    public function handle($request, Closure $next, ... $roles)
     {
-        $roles = [$roleCollection];
-
-        if (strpos($roleCollection, '|') > 0) {
-            $roles = explode('|', $roleCollection);
-        }
-
         foreach ($roles as $role) {
             if ($request->user()->hasRole($role)) {
                 return $next($request);


### PR DESCRIPTION
Hi,
To be more compliant with classic middleware parameters which are comma separated, I suggest this PR.
This PR is not retro-compatible.
Here is the laravel doc link : https://laravel.com/docs/5.6/middleware#middleware-parameters
Thx for your wonderfull work!