### PR TITLE
remove call for meta property

### DIFF
--- a/src/Packages/Starter/app/Http/Middleware/Active.php
+++ b/src/Packages/Starter/app/Http/Middleware/Active.php
@@ -34,7 +34,7 @@ class Active
      */
     public function handle($request, Closure $next)
     {
-        if (! $this->auth->user()->meta->is_active) {
+        if (! $this->auth->user()->is_active) {
             return redirect()->guest('activate');
         }
 


### PR DESCRIPTION
I was getting an error logging into the admin dashboard after seeding saying trying to get property of non-object. Removing this property fixed the error