### PR TITLE
Update the Starter command to handle base_paths with a space

### DIFF
--- a/src/Console/Starter.php
+++ b/src/Console/Starter.php
@@ -86,7 +86,7 @@ class Starter extends Command
             if ($this->confirm('Would you like to run the migration?')) {
                 $this->comment('Running command: cd '.base_path().' && composer dump ...');
 
-                exec('cd '.base_path().' && composer dump');
+                exec(sprintf('cd %s && composer dump', escapeshellarg(base_path()));
 
                 // execute migrate artisan command
                 Artisan::call('migrate');


### PR DESCRIPTION
This PR will update the start command to handle the `base_path`s that have a space in it. For me, I'm trying to install and set up things at `/Volumes/Code Repository/newsite` the fact my partition has a space in it made the whole install die.

Here's a bit of my trace that this is suppose to fix.

```
 Would you like to run the migration? (yes/no) [no]:
 > yes

Running command: cd /Volumes/Code Repository/Sites/newsite && composer dump ...
sh: line 0: cd: /Volumes/Code: No such file or directory

   ReflectionException  : Class RolesTableSeeder does not exist

  at /Volumes/Code Repository/Sites/newsite/vendor/laravel/framework/src/Illuminate/Container/Container.php:767
    763|         if ($concrete instanceof Closure) {
    764|             return $concrete($this, $this->getLastParameterOverride());
    765|         }
    766|
  > 767|         $reflector = new ReflectionClass($concrete);
    768|
    769|         // If the type is not instantiable, the developer is attempting to resolve
    770|         // an abstract type such as an Interface of Abstract Class and there is
    771|         // no binding registered for the abstractions so we need to bail out.
```